### PR TITLE
Don't reduce alpha for brand color text

### DIFF
--- a/colors/index.js
+++ b/colors/index.js
@@ -148,7 +148,7 @@ const themeColors = [
 const textColors = [
   {
     dark: {
-      primary: colorWithEmphasis(namedColors.darkGrey, 'high'),
+      primary: colorWithEmphasis(namedColors.darkGrey, 1),
       secondary: colorWithEmphasis(namedColors.slate, 'high'),
       hint: colorWithEmphasis(namedColors.darkGrey, 'disabled'),
       disabled: colorWithEmphasis(namedColors.darkGrey, 'disabled'),


### PR DESCRIPTION
This medium grey font is looking too light because its opacity is reduced to 87%